### PR TITLE
Improve summary fallback handling

### DIFF
--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -214,7 +214,7 @@ export default function Logs() {
                       {formatTime(log.createdAt)}
                     </p>
                     
-                    {log.details && (
+                    {log.details != null && (
                       <details className="mt-2">
                         <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
                           View details


### PR DESCRIPTION
## Summary
- harden AI summary parsing to fall back when the model response is missing or malformed
- add a richer locally-generated summary template so summaries never contain empty placeholder text
- fix the logs page conditional so TypeScript accepts optional details data

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8bef9f2248320aa7106bddd39e479